### PR TITLE
Updated donate page to reference Open Collective

### DIFF
--- a/donate.html
+++ b/donate.html
@@ -63,17 +63,13 @@
                             <h1 class="text-center">Donations</h1>
                             <p>
                                 Even the smallest donation from you will help us keep everything up and running so we can continue to provide our great services.
-                                We are always eternally grateful for the donations we receive. Everyone at LinuxServer is a volunteer. We don't get paid to do this &mdash; we try our best to make the most of our free time to continue improving what we do. If you love what we do, why not drop us a bit of beer money to say thanks. Cheers!
+                                We are always eternally grateful for the donations we receive. Everyone at LinuxServer is a volunteer. We don't get paid to do this &mdash; we try our best to make the most of our free time to continue improving what we do. If you love what we do, please consider helping us by either donating or contributing to our budget. Cheers!
                             </p>
                         </div>
                         <div class="col-md-12 text-center mt-5">
-                            <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_blank">
-                                <input type="hidden" name="cmd" value="_s-xclick" />
-                                <input type="hidden" name="hosted_button_id" value="PVYA74KK8C9D2"/>
-                                <button type="submit" class="btn btn-warning btn-lg" name="submit" alt="PayPal – The safer, easier way to pay online!">
-                                    Donate
-                                </button>
-                            </form>
+                            <a href="https://opencollective.com/linuxserver/donate" target="_blank">
+                                <img src="https://opencollective.com/linuxserver/donate/button@2x.png?color=blue" width=300 />
+                            </a>
                         </div>
                     </div>
                 </div>

--- a/privacy.html
+++ b/privacy.html
@@ -247,9 +247,9 @@
             </div>
             <div class="row">
                 <div class="col-md-12">
-                    <h5>PayPal</h5>
+                    <h5>Open Collective</h5>
                     <p>
-                        LinuxServer.io provides a means for its users to donate via PayPal. The provider of this service is PayPal (Europe) S.à.r.l & Cie, S.C.A. (22-24 Boulevard Royal, L-2449 Luxembourg. Any donations/payments made to LinuxServer.io will include the payment data supplied to PayPal. As part of internal book keeping, LinuxServer.io stores in part, some information pertaining to any transaction made by you via PayPal. You maintain the right to request this data at any time.
+                        LinuxServer.io provides a means for its users to donate via the Open Collective. Any donations/payments made to LinuxServer.io will include the payment data supplied to Open Collective. The LinuxServer.io team maintains no copies of transaction data made via the Open Collective.
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
Donations have moved to the Open Collective away from PayPal. The website has been updated to take that into account.

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]